### PR TITLE
Create certificates using a rolling state

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -112,10 +112,8 @@ pub struct State {
 
 impl State {
     pub fn with_key_pair(provider_kp: SignKeyPair, key_cache_capacity: usize) -> Self {
-        let dnscrypt_encryption_params_set = vec![DNSCryptEncryptionParams::new(
-            &provider_kp,
-            key_cache_capacity,
-        )];
+        let dnscrypt_encryption_params_set =
+            DNSCryptEncryptionParams::new(&provider_kp, key_cache_capacity, None);
         State {
             provider_kp,
             dnscrypt_encryption_params_set,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -132,12 +132,15 @@ pub struct CryptKeyPair {
 }
 
 impl CryptKeyPair {
-    pub fn new() -> Self {
+    pub fn from_seed(
+        seed: [u8; crypto_box_curve25519xchacha20poly1305_SEEDBYTES as usize],
+    ) -> Self {
         let mut kp = CryptKeyPair::default();
         unsafe {
-            crypto_box_curve25519xchacha20poly1305_keypair(
+            crypto_box_curve25519xchacha20poly1305_seed_keypair(
                 kp.pk.0.as_mut_ptr(),
                 kp.sk.0.as_mut_ptr(),
+                seed.as_ptr(),
             )
         };
         kp


### PR DESCRIPTION
A new key pair is now computed using the previous secret key as a seed.

This still provides forward secrecy, and allows multiple instances
to compute the same ephemeral keys without having to share a state.

Fixes #57
Fixes #27